### PR TITLE
Destructure props to allow Formsy to control value

### DIFF
--- a/formsy-material-ui.jsx
+++ b/formsy-material-ui.jsx
@@ -107,7 +107,7 @@ let FormsyText = React.createClass({
     return (
       <TextField
         {...this.props}
-        onBlur={this.handleChange}
+        onChange={this.handleChange}
         errorText={this.getErrorMessage()}
         value={this.getValue()} />
     );

--- a/formsy-material-ui.jsx
+++ b/formsy-material-ui.jsx
@@ -94,7 +94,8 @@ let FormsySelect = React.createClass({
       <SelectField
         {...this.props}
         onChange={this.handleChange}
-        value={this.getValue()} />
+        value={this.getValue()}
+        errorText={this.getErrorMessage()} />
     );
   }
 });


### PR DESCRIPTION
Fixes #3

This commit addresses the issue of Formsy not being able to track form canSubmit state. Formsy requires the usage of the value prop to track internal state and allow the onValid and onInvalid callbacks to work properly.

Note that only the following Components were modiifed:

`FormsyDate, FormsyText, FormSelect`

There may be more work to do with the other MUI Components.