### PR TITLE
added errorText to FormsySelect

### DIFF
--- a/formsy-material-ui.jsx
+++ b/formsy-material-ui.jsx
@@ -94,6 +94,7 @@ let FormsySelect = React.createClass({
       <SelectField
         {...this.props}
         onChange={this.handleChange}
+        errorText={this.getErrorMessage()}
         value={this.getValue()} />
     );
   }


### PR DESCRIPTION
@mbrookes this PR just adds the errorText prop to FormsySelect. There are other components, like RadioGroup that may need an errorText prop too. But I think it's safer to look at those separately from this PR.