### PR TITLE
Fix TextField not being loaded in material-ui 0.14.1

### DIFF
--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const Formsy = require('formsy-react');
-const TextField = require('material-ui/lib/text-field');
+const TextField = require('material-ui').TextField;
 
 let FormsyText = React.createClass({
   mixins: [ Formsy.Mixin ],


### PR DESCRIPTION
After upgrading material-ui to latest version (0.14.1) I found out that formsy-material-ui couldn't load TextField. I changed the code a bit: using material-ui proxy (index.js) instead of loading the component explicitly. Not really sure that same issue on other components, I will check it later on.