### PR TITLE
[FormsySelect] Add support for composable SelectField

### DIFF
--- a/lib/FormsySelect.js
+++ b/lib/FormsySelect.js
@@ -25,15 +25,29 @@ var FormsySelect = _react2['default'].createClass({
     name: _react2['default'].PropTypes.string.isRequired
   },
 
-  handleChange: function handleChange(event) {
-    this.setValue(event.target.value);
+  getInitialState: function getInitialState() {
+    return {
+      hasChanged: false
+    };
+  },
+
+  handleChange: function handleChange(event, index, value) {
+    this.setValue(value);
+    this.setState({ hasChanged: true });
   },
 
   render: function render() {
-    return _react2['default'].createElement(_materialUiLibSelectField2['default'], _extends({}, this.props, {
-      onChange: this.handleChange,
-      errorText: this.getErrorMessage(),
-      value: this.getValue() }));
+    var value = this.state.hasChanged ? this.getValue() : this.props.value;
+
+    return _react2['default'].createElement(
+      _materialUiLibSelectField2['default'],
+      _extends({}, this.props, {
+        onChange: this.handleChange,
+        errorText: this.getErrorMessage(),
+        value: value
+      }),
+      this.props.children
+    );
   }
 });
 

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -9,17 +9,29 @@ let FormsySelect = React.createClass({
     name: React.PropTypes.string.isRequired
   },
 
-  handleChange: function (event) {
-    this.setValue(event.target.value);
+  getInitialState: function () {
+    return {
+      hasChanged: false,
+    };
+  },
+
+  handleChange: function (event, index, value) {
+    this.setValue(value);
+    this.setState({hasChanged: true});
   },
 
   render: function () {
+    var value = this.state.hasChanged ? this.getValue() : this.props.value;
+
     return (
       <SelectField
         {...this.props}
         onChange={this.handleChange}
         errorText={this.getErrorMessage()}
-        value={this.getValue()} />
+        value={value}
+      >
+        {this.props.children}
+      </SelectField>
     );
   }
 });


### PR DESCRIPTION
fix #40 
Fixes issues with `DropDownMenu` where it wants `MenuItems` passed as children (composability).

`handleChange` reflects updates to the material-ui API. It takes `(event, index, value)` so we can directly access the `value`, rather than going through `event.target.value`.

It adds a `state` variable `hasChanged` for deciding whether to pass the initial `props.value` (there is no unique `initialValue` prop) or the formsy mixin method `this.getValue()`.