### PR TITLE
Allow onChange event to propagate up.

### DIFF
--- a/lib/FormsySelect.js
+++ b/lib/FormsySelect.js
@@ -36,6 +36,7 @@ var FormsySelect = _react2['default'].createClass({
   handleChange: function handleChange(event, index, value) {
     this.setValue(value);
     this.setState({ hasChanged: true });
+    if (this.props.onChange) this.props.onChange(event, index, value);
   },
 
   _setMuiComponentAndMaybeFocus: _utils._setMuiComponentAndMaybeFocus,

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -19,6 +19,7 @@ let FormsySelect = React.createClass({
   handleChange: function (event, index, value) {
     this.setValue(value);
     this.setState({hasChanged: true});
+    if (this.props.onChange) this.props.onChange(event, index, value);
   },
 
   _setMuiComponentAndMaybeFocus: _setMuiComponentAndMaybeFocus,


### PR DESCRIPTION
I need the new value from the select to change something on the page in real time, without actually saving, so I needed to tap into the onChange event.  You might consider adding this to the other components as well. (Or I will as needed. ;)

Awesome repo BTW. MOO! =)