### PR TITLE
Use defaultDate rather than defaultValue in FormsyDate

### DIFF
--- a/src/FormsyDate.jsx
+++ b/src/FormsyDate.jsx
@@ -24,7 +24,7 @@ let FormsyDate = React.createClass({
         formatDate={(date) => (new Date(date.toDateString()+" 12:00:00 +0000")).toISOString().substring(0,10)}
         {...this.props}
         ref={this._setMuiComponentAndMaybeFocus}
-        defaultValue={this.props.value}
+        defaultDate={this.props.value}
         onChange={this.handleValueChange}
         errorText={this.getErrorMessage()}
         value={this.getValue()}

--- a/src/FormsyTime.jsx
+++ b/src/FormsyTime.jsx
@@ -23,6 +23,8 @@ let FormsyTime = React.createClass({
         {...this.props}
         ref={this._setMuiComponentAndMaybeFocus}
         onChange={this.handleValueChange}
+        defaultTime={this.props.value}
+        value={this.getValue()}
       />
     );
   }


### PR DESCRIPTION
Using defaultValue produces strange behaviour on date pickers.

The docs state that defaultDate should be used.
http://www.material-ui.com/#/components/date-picker