### PR TITLE
[FormsySelect] Don't set hasChanged for empty value

### DIFF
--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -18,7 +18,7 @@ let FormsySelect = React.createClass({
 
   handleChange: function (event, index, value) {
     this.setValue(value);
-    this.setState({hasChanged: true});
+    this.setState({hasChanged: value !== ''});
     if (this.props.onChange) this.props.onChange(event, value, index);
   },
 


### PR DESCRIPTION
For now, when value of currently selected `MenuItem` in a `ForsySelect` is empty,

`hintText` for `FormsySelect` and `primaryText` for `MenuItem` are rendered at the same time.

This patch would hide `primaryText` for `MenuItem` when its value is empty.

Fixes #58