### PR TITLE
modified text component proptype to allow any data type for value prop

### DIFF
--- a/lib/FormsyText.js
+++ b/lib/FormsyText.js
@@ -25,7 +25,7 @@ var FormsyText = _react2.default.createClass({
 
   propTypes: {
     name: _react2.default.PropTypes.string.isRequired,
-    value: _react2.default.PropTypes.string,
+    value: _react2.default.PropTypes.any,
     onFocus: _react2.default.PropTypes.func,
     onBlur: _react2.default.PropTypes.func
   },

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -8,7 +8,7 @@ let FormsyText = React.createClass({
 
   propTypes: {
     name: React.PropTypes.string.isRequired,
-    value: React.PropTypes.string,
+    value: React.PropTypes.any,
     onFocus: React.PropTypes.func,
     onBlur: React.PropTypes.func
   },


### PR DESCRIPTION
This will allow any datatype to be passed in the value property for the FormsyText component, which is what the material-ui TextField accepts.