### PR TITLE
Removing dependency on onEnterKeyDown and using onKeyDown as per material-ui request (onEnterKeyDown deprecated)

### DIFF
--- a/lib/FormsyText.js
+++ b/lib/FormsyText.js
@@ -6,6 +6,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _keycode = require('keycode');
+
+var _keycode2 = _interopRequireDefault(_keycode);
+
 var _formsyReact = require('formsy-react');
 
 var _formsyReact2 = _interopRequireDefault(_formsyReact);
@@ -53,6 +57,11 @@ var FormsyText = _react2.default.createClass({
     if (this.props.onBlur) this.props.onBlur(event);
   },
 
+  handleKeyDown: function handleKeyDown(event) {
+    if ((0, _keycode2.default)(event) === 'enter') this.handleEnterKeyDown(event);
+    if (this.props.onKeyDown) this.props.onKeyDown(event, event.currentTarget.value);
+  },
+
   handleEnterKeyDown: function handleEnterKeyDown(event) {
     this.setValue(event.currentTarget.value);
     if (this.props.onEnterKeyDown) this.props.onEnterKeyDown(event, event.currentTarget.value);
@@ -67,7 +76,7 @@ var FormsyText = _react2.default.createClass({
       onChange: this.handleChange,
       onBlur: this.handleBlur,
       onFocus: this.props.onFocus,
-      onEnterKeyDown: this.handleEnterKeyDown,
+      onKeyDown: this.handleKeyDown,
       errorText: this.getErrorMessage(),
       value: this.getValue()
     }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {
@@ -11,6 +11,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mbrookes/formsy-material-ui.git"
+  },
+  "dependencies": {
+    "keycode": "^2.1.0"
   },
   "peerDependencies": {
     "formsy-react": ">=0.14.1 <1"

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import keycode from 'keycode';
 import Formsy from 'formsy-react';
 import TextField from 'material-ui/lib/text-field';
 import { _setMuiComponentAndMaybeFocus } from './utils';
@@ -38,6 +39,11 @@ let FormsyText = React.createClass({
     if (this.props.onBlur) this.props.onBlur(event);
   },
 
+  handleKeyDown: function handleKeyDown(event) {
+    if (keycode(event) === 'enter') this.handleEnterKeyDown(event);
+    if (this.props.onKeyDown) this.props.onKeyDown(event, event.currentTarget.value);
+  },
+
   handleEnterKeyDown: function handleEnterKeyDown(event) {
     this.setValue(event.currentTarget.value);
     if (this.props.onEnterKeyDown) this.props.onEnterKeyDown(event, event.currentTarget.value);
@@ -54,7 +60,7 @@ let FormsyText = React.createClass({
         onChange={this.handleChange}
         onBlur={this.handleBlur}
         onFocus={this.props.onFocus}
-        onEnterKeyDown={this.handleEnterKeyDown}
+        onKeyDown={this.handleKeyDown}
         errorText={this.getErrorMessage()}
         value={this.getValue()}
       />


### PR DESCRIPTION
Closes #60