### PR TITLE
Value property must not be passed in to FormsyText

### DIFF
--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -27,11 +27,13 @@ let FormsyText = React.createClass({
   _setMuiComponentAndMaybeFocus: _setMuiComponentAndMaybeFocus,
 
   render: function () {
+    // value must not be passed in, because it makes the field value unchangeable.
+    const { value, ...props } = this.props;
     return (
       <TextField
-        {...this.props}
+        {...props}
         ref={this._setMuiComponentAndMaybeFocus}
-        defaultValue={this.props.value}
+        defaultValue={value}
         onBlur={this.handleBlur}
         onFocus={this.props.onFocus}
         onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
Because it makes the field value unchangeable. That means that if you pass in a value to FormsyText, then since we pass ...this.props, then not only 'defaultValue', but also 'value' will be passed to TextField, and as a result, the user can never change the value of the text field.

This started to happen when I updated to material-ui 0.15.0-beta.1. 

Fixes #87.
