### PR TITLE
Fix text input values

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "formsy-react": "^0.18.0",
-    "material-ui": "0.15.0-beta.1",
+    "material-ui": "^0.15.0",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },
@@ -55,7 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "material-ui": "0.15.0-beta.1",
+    "material-ui": "^0.15.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.4",
     "react": "^15.0.0",

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -18,14 +18,26 @@ const FormsyText = React.createClass({
 
   mixins: [Formsy.Mixin],
 
+  controlledValue(props = this.props) {
+    return props.value || props.defaultValue || '';
+  },
+
   getInitialState() {
-    return {
-      value: this.props.defaultValue || this.props.value || '',
-    };
+    const value = this.controlledValue();
+    return { value };
   },
 
   componentWillMount() {
-    this.setValue(this.props.defaultValue || this.props.value || '');
+    const value = this.controlledValue();
+    this.setValue(value);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.value !== this.props.value || nextProps.defaultValue !== this.props.defaultValue) {
+      const value = this.controlledValue(nextProps);
+      this.setValue(value);
+      this.setState({ value });
+    }
   },
 
   handleBlur: function handleBlur(event) {


### PR DESCRIPTION
I'm testing this version in a project of mine. The last fix was definitely the right direction, but I still found some problems. This PR fixes the followings:

1. Instead of

  ```javascript
  this.props.defaultValue || this.props.value || ''
  ```

  we have to use

  ```javascript
  this.props.value || this.props.defaultValue || ''
  ```

  This allows the use of both a defaultValue and a value (controlled case), and allows the value to take precedent. (Currently it's the wrong way around.)


2. Similar to componentWillMount, there is also a need for a componentWillReceiveProps. This covers the case when the form gets reloaded with new values, and allows the defaultValue-s change on the fly, taking care of the pristine values working correctly in this case.


3. The controlledValue I just introduced is just a helper, it does not do anything other than it makes the code shorter.

4. Meanwhile, material-ui 0.15 has been released, so I had to bump the peer dependencies.

I'm testing this for a while, and it works well with my use case.

