### PR TITLE
shows requiredError on submit

### DIFF
--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -9,6 +9,7 @@ const FormsySelect = React.createClass({
     children: React.PropTypes.node,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    requiredError: React.PropTypes.string,
     value: React.PropTypes.any,
   },
 
@@ -35,11 +36,14 @@ const FormsySelect = React.createClass({
   render() {
     let { value, ...rest } = this.props;
     value = this.state.hasChanged ? this.getValue() : value;
-
+    const { requiredError } = this.props;
+    const { isRequired, isPristine, isValid, isFormSubmitted } = this;
+    const isRequiredError = isRequired() && !isPristine() && !isValid() && isFormSubmitted() && requiredError;
+    const errorText = this.getErrorMessage() || isRequiredError;
     return (
       <SelectField
         {...rest}
-        errorText={this.getErrorMessage()}
+        errorText={errorText}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
         value={value}

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import keycode from 'keycode';
 import Formsy from 'formsy-react';
 import TextField from 'material-ui/TextField';
-import { setMuiComponentAndMaybeFocus } from 'formsy-material-ui/lib/utils';
+import { setMuiComponentAndMaybeFocus } from './utils';
 
 const FormsyText = React.createClass({
 

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -48,12 +48,12 @@ const FormsyText = React.createClass({
 
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
-  render () {
+  render() {
     const {
       defaultValue, // eslint-disable-line no-unused-vars
       onFocus,
-      value, // eslint-disable-line no-unused-vars
       requiredError,
+      value, // eslint-disable-line no-unused-vars
       ...rest } = this.props;
     const { isRequired, isPristine, isValid, isFormSubmitted } = this;
     const isRequiredError = isRequired() && !isPristine() && !isValid() && isFormSubmitted() && requiredError;

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import keycode from 'keycode';
 import Formsy from 'formsy-react';
 import TextField from 'material-ui/TextField';
-import { setMuiComponentAndMaybeFocus } from './utils';
+import { setMuiComponentAndMaybeFocus } from 'formsy-material-ui/lib/utils';
 
 const FormsyText = React.createClass({
 
@@ -13,6 +13,7 @@ const FormsyText = React.createClass({
     onChange: React.PropTypes.func,
     onFocus: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
+    requiredError: React.PropTypes.string,
     value: React.PropTypes.any,
   },
 
@@ -47,16 +48,20 @@ const FormsyText = React.createClass({
 
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
-  render() {
+  render () {
     const {
       defaultValue, // eslint-disable-line no-unused-vars
       onFocus,
       value, // eslint-disable-line no-unused-vars
+      requiredError,
       ...rest } = this.props;
+    const { isRequired, isPristine, isValid, isFormSubmitted } = this;
+    const isRequiredError = isRequired() && !isPristine() && !isValid() && isFormSubmitted() && requiredError;
+    const errorText = this.getErrorMessage() || isRequiredError;
     return (
       <TextField
         {...rest}
-        errorText={this.getErrorMessage()}
+        errorText={errorText}
         onBlur={this.handleBlur}
         onChange={this.handleChange}
         onFocus={onFocus}


### PR DESCRIPTION
Will display whatever string is passed to `requiredError` on submit, if there `required` is true and there are no other validation errors. Should fix #28 and #5.

Thanks to @albertolive on https://github.com/christianalfoni/formsy-react/issues/334.
