### PR TITLE
[FormsyText] Add updateImmediately prop & fix handleChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Changelog
 
-* HEAD  Lint jsx files - fix linting errors in same
+* 0.5.0  Lint jsx files - fix linting errors in same
+         Accepts Formsy.Form.reset() (@Mokto)q
+         Fix text input values, and form reset (@reebalazs)
+         Fixes React 15.2 unknown props warnings (@jayalfredprufrock)
 
 * 0.4.2 Fix controlled / uncontrolled conflicts
         Add defaultValue support to FormsyText 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import { FormsyCheckbox, FormsyDate, FormsyRadio, FormsyRadioGroup,
 ### Events
 
 Components allow for `onChange` event handlers in props. They are fired when the value of the 
-component changes, regardless of the underlying handler (eg, `FomrsyToggle` uses `onToggle` internally, but we
+component changes, regardless of the underlying handler (eg, `FormsyToggle` uses `onToggle` internally, but we
 still use `onChange` in props to hook into the event.)
 
 The call back signatures for all `onChange` handlers conform to 

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "formsy-react": "^0.18.0",
-    "formsy-material-ui": "0.4.2",
+    "formsy-material-ui": "0.5.0",
     "material-ui": "^0.15.0",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/examples/webpack-example/src/app/Main.js
+++ b/examples/webpack-example/src/app/Main.js
@@ -83,28 +83,15 @@ const Main = React.createClass({
             onValidSubmit={this.submitForm}
             onInvalidSubmit={this.notifyFormError}
           >
-            <FormsyText
-              name="name"
-              validations="isWords"
-              validationError={wordsError}
+            <FormsyDate
+              name="date"
               required
-              hintText="What is your name?"
-              floatingLabelText="Name"
+              floatingLabelText="Date"
             />
-            <FormsyText
-              name="age"
-              validations="isNumeric"
-              validationError={numericError}
-              hintText="Are you a wrinkly?"
-              floatingLabelText="Age (optional)"
-            />
-            <FormsyText
-              name="url"
-              validations="isUrl"
-              validationError={urlError}
+            <FormsyTime
+              name="time"
               required
-              hintText="http://www.example.com"
-              floatingLabelText="URL"
+              floatingLabelText="Time"
             />
             <FormsySelect
               name="frequency"
@@ -116,16 +103,6 @@ const Main = React.createClass({
               <MenuItem value={'nightly'} primaryText="Every Night" />
               <MenuItem value={'weeknights'} primaryText="Weeknights" />
             </FormsySelect>
-            <FormsyDate
-              name="date"
-              required
-              floatingLabelText="Date"
-            />
-            <FormsyTime
-              name="time"
-              required
-              floatingLabelText="Time"
-            />
             <FormsyCheckbox
               name="agree"
               label="Do you agree to disagree?"
@@ -154,6 +131,30 @@ const Main = React.createClass({
                 disabled={true}
               />
             </FormsyRadioGroup>
+            <FormsyText
+              name="name"
+              validations="isWords"
+              validationError={wordsError}
+              required
+              hintText="What is your name?"
+              floatingLabelText="Name"
+            />
+            <FormsyText
+              name="age"
+              validations="isNumeric"
+              validationError={numericError}
+              hintText="Are you a wrinkly?"
+              floatingLabelText="Age (optional)"
+            />
+            <FormsyText
+              name="url"
+              validations="isUrl"
+              validationError={urlError}
+              required
+              hintText="http://www.example.com"
+              floatingLabelText="URL"
+              updateImmediately
+            />
             <RaisedButton
               style={submitStyle}
               type="submit"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "material-ui": "0.15.0-beta.1",
+    "material-ui": "^0.15.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.4",
     "react": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/FormsyCheckbox.jsx
+++ b/src/FormsyCheckbox.jsx
@@ -9,6 +9,9 @@ const FormsyCheckbox = React.createClass({
     defaultChecked: React.PropTypes.bool,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
   },
 
   mixins: [Formsy.Mixin],
@@ -25,7 +28,12 @@ const FormsyCheckbox = React.createClass({
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
   render() {
-    const { defaultChecked, ...rest } = this.props;
+    const {
+      defaultChecked, // eslint-disable-line no-unused-vars
+      validations, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      ...rest } = this.props;
     let value = this.getValue();
 
     if (typeof value === 'undefined') {

--- a/src/FormsyDate.jsx
+++ b/src/FormsyDate.jsx
@@ -9,6 +9,9 @@ const FormsyDate = React.createClass({
     defaultDate: React.PropTypes.object,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
     value: React.PropTypes.object,
   },
 
@@ -32,9 +35,11 @@ const FormsyDate = React.createClass({
 
   render() {
     const {
-        defaultDate, // eslint-disable-line no-unused-vars
-        ...rest,
-    } = this.props;
+      defaultDate, // eslint-disable-line no-unused-vars
+      validations, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      ...rest } = this.props;
 
     return (
       <DatePicker

--- a/src/FormsyRadioGroup.jsx
+++ b/src/FormsyRadioGroup.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Formsy from 'formsy-react';
-import { RadioButtonGroup } from 'material-ui/RadioButton';
+import { RadioButtonGroup, RadioButton } from 'material-ui/RadioButton';
 import { setMuiComponentAndMaybeFocus } from './utils';
 
 const FormsyRadioGroup = React.createClass({
@@ -9,6 +9,9 @@ const FormsyRadioGroup = React.createClass({
     children: React.PropTypes.node,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
   },
 
   mixins: [Formsy.Mixin],
@@ -25,13 +28,30 @@ const FormsyRadioGroup = React.createClass({
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
   render() {
+    const {
+      validations, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
+      ...rest } = this.props;
+
+      // remove unknown props from children
+    const children = React.Children.map(this.props.children, (radio) => {
+      const {
+        validations, // eslint-disable-line no-unused-vars
+        validationError, // eslint-disable-line no-unused-vars
+        validationErrors, // eslint-disable-line no-unused-vars
+        ...rest } = radio.props;
+
+      return React.createElement(RadioButton, rest);
+    });
+
     return (
       <RadioButtonGroup
-        {...this.props}
+        {...rest}
         ref={this.setMuiComponentAndMaybeFocus}
         onChange={this.handleValueChange}
       >
-        {this.props.children}
+        {children}
       </RadioButtonGroup>
     );
   },

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -9,6 +9,9 @@ const FormsySelect = React.createClass({
     children: React.PropTypes.node,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
     value: React.PropTypes.any,
   },
 
@@ -33,7 +36,13 @@ const FormsySelect = React.createClass({
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
   render() {
-    let { value, ...rest } = this.props;
+    let { value } = this.props;
+
+    const { validations, // eslint-disable-line no-unused-vars
+        validationError, // eslint-disable-line no-unused-vars
+        validationErrors, // eslint-disable-line no-unused-vars
+      ...rest } = this.props;
+
     value = this.state.hasChanged ? this.getValue() : value;
 
     return (

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -27,6 +27,10 @@ const FormsyText = React.createClass({
   componentWillMount() {
     this.setValue(this.props.defaultValue || this.props.value || '');
   },
+  
+  componentWillReceiveProps(props) {
+    this.setState({ value: this.getValue() || '' });
+  },
 
   handleBlur: function handleBlur(event) {
     this.setValue(event.currentTarget.value);

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -18,18 +18,38 @@ const FormsyText = React.createClass({
 
   mixins: [Formsy.Mixin],
 
+
   getInitialState() {
-    return {
-      value: this.props.defaultValue || this.props.value || '',
-    };
+    return { value: this.controlledValue() };
   },
 
   componentWillMount() {
-    this.setValue(this.props.defaultValue || this.props.value || '');
+    this.setValue(this.controlledValue());
   },
-  
-  componentWillReceiveProps(props) {
-    this.setState({ value: this.getValue() || '' });
+
+  componentWillReceiveProps(nextProps) {
+    const isValueChanging = nextProps.value !== this.props.value;
+    if (isValueChanging || nextProps.defaultValue !== this.props.defaultValue) {
+      const value = this.controlledValue(nextProps);
+      if (isValueChanging || this.props.defaultValue === this.getValue()) {
+        this.setState({ value });
+        this.setValue(value);
+      }
+    }
+  },
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState._isPristine && // eslint-disable-line no-underscore-dangle
+      nextState._isPristine !== this.state._isPristine) { // eslint-disable-line no-underscore-dangle
+      // Calling state here is valid, as it cannot cause infinite recursion.
+      const value = this.controlledValue(nextProps);
+      this.setValue(value);
+      this.setState({ value });
+    }
+  },
+
+  controlledValue(props = this.props) {
+    return props.value || props.defaultValue || '';
   },
 
   handleBlur: function handleBlur(event) {

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -13,6 +13,9 @@ const FormsyText = React.createClass({
     onChange: React.PropTypes.func,
     onFocus: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
     value: React.PropTypes.any,
   },
 
@@ -74,6 +77,9 @@ const FormsyText = React.createClass({
   render() {
     const {
       defaultValue, // eslint-disable-line no-unused-vars
+      validations, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
       onFocus,
       value, // eslint-disable-line no-unused-vars
       ...rest } = this.props;

--- a/src/FormsyTime.jsx
+++ b/src/FormsyTime.jsx
@@ -9,6 +9,9 @@ const FormsyTime = React.createClass({
     defaultTime: React.PropTypes.object,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
     value: React.PropTypes.object,
   },
 
@@ -33,6 +36,9 @@ const FormsyTime = React.createClass({
   render() {
     const {
       defaultTime, // eslint-disable-line no-unused-vars
+      validations, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
       ...rest,
     } = this.props;
 

--- a/src/FormsyToggle.jsx
+++ b/src/FormsyToggle.jsx
@@ -9,6 +9,9 @@ const FormsyToggle = React.createClass({
     defaultToggled: React.PropTypes.bool,
     name: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func,
+    validationError: React.PropTypes.string,
+    validationErrors: React.PropTypes.object,
+    validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
   },
 
   mixins: [Formsy.Mixin],
@@ -25,7 +28,13 @@ const FormsyToggle = React.createClass({
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
   render() {
-    const { defaultToggled, ...rest } = this.props;
+    const {
+      defaultToggled,
+      validations, // eslint-disable-line no-unused-vars
+      validationError, // eslint-disable-line no-unused-vars
+      validationErrors, // eslint-disable-line no-unused-vars
+      ...rest } = this.props;
+
     let value = this.getValue();
 
     if (typeof value === 'undefined') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,3 +9,14 @@ export function setMuiComponentAndMaybeFocus(c) {
     delete this.focus;
   }
 }
+
+export function debounce(fn, delay) {
+  let timeout;
+  return function() {
+    const args = arguments;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      fn.apply(this, args);
+    }, delay);
+  };
+}

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -1,14 +1,30 @@
 /* eslint-env mocha, jasmine */
 /* global expect */
 
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import FormsyText from '../src/FormsyText';
 import TextField from 'material-ui/TextField';
 import { Simulate } from 'react-addons-test-utils';
 import { mountTestForm } from './support';
 import { Form } from 'formsy-react';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import { mount } from 'enzyme';
 
-const setup = () => {
+function makeChildrenFn(props) {
+  const fn = () => (
+    <FormsyText ref="text"
+      name="text"
+      validations="maxLength:10"
+      validationErrors={{ maxLength: 'Text is too long' }}
+      { ...props }
+    />
+  );
+  fn.DisplayName = 'FormsyText';
+  return fn;
+}
+
+const setup = (props) => {
+  const childrenFn = makeChildrenFn(props);
   const formWrapper = mountTestForm(childrenFn);
   const formsyTextWrapper = formWrapper.find(FormsyText);
   return {
@@ -17,18 +33,51 @@ const setup = () => {
   };
 };
 
-const childrenFn = () => (
-  <FormsyText
-    name="text"
-    validations="maxLength:10"
-    validationErrors={{ maxLength: 'Text is too long' }}
-  />
-);
+class TestForm extends Component {
+
+  static childContextTypes = {
+    muiTheme: PropTypes.object.isRequired,
+  };
+
+  static propTypes = {
+    defaultValue: PropTypes.string,
+    value: PropTypes.string,
+  }
+
+  getChildContext() {
+    return { muiTheme: getMuiTheme() };
+  }
+
+  componentWillMount() {
+    const { value, defaultValue } = this.props;
+    this.state = { value, defaultValue };
+  }
+
+  render() {
+    const { value, defaultValue, ...extraProps } = { ...this.props, ...this.state };
+    return (
+      <Form { ...extraProps }>
+        <FormsyText ref="text" name="text"
+          value={value}
+          defaultValue={defaultValue}
+        />
+      </Form>
+    );
+  }
+}
+
+function makeTestParent(props) {
+  const parent = mount(<TestForm {...props} />);
+  const formWrapper = parent.find(Form);
+  const formsyTextWrapper = parent.find(FormsyText);
+  return { parent, formWrapper, formsyTextWrapper };
+}
 
 const fillInText = (wrapper, text) => {
   const inputDOM = wrapper.find('input').node;
   inputDOM.value = text;
   Simulate.change(inputDOM);
+  Simulate.blur(inputDOM);
 };
 
 describe('FormsyText', () => {
@@ -58,5 +107,133 @@ describe('FormsyText', () => {
     fillInText(formsyTextWrapper, 'just fine');
     formsyForm.validateForm();
     expect(formsyTextWrapper).to.not.contain.text('Text is too long');
+  });
+
+  describe('value properties handle', () => {
+    describe('initial', () => {
+      it('value', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+
+      it('defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('DEFAULT-VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+
+      it('value + defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+    });
+
+    describe('updating', () => {
+      it('value', () => {
+        const props = {
+          value: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ value: 'NEW VALUE' });
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+        parent.setState({ value: 'NEWER VALUE' });
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEWER VALUE');
+      });
+
+      it('defaultValue', () => {
+        const props = {
+          defaultValue: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ defaultValue: 'NEW VALUE' });
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+        parent.setState({ defaultValue: 'NEWER VALUE' });
+        // defaultValues does not override the typed in value.
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+    });
+
+    describe('resetting to', () => {
+      it('value', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          defaultValue: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('value + defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('updated value', () => {
+        const props = {
+          value: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ value: 'NEW VALUE' });
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        // Reset reverts to the last value that has been set.
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+      });
+    });
   });
 });


### PR DESCRIPTION
I believe this resolves the various issues for both use cases. Let me know!

This is based in part on and supersedes @codaholicguy's PR: #103.

If you use `onValid` / `onInvalid` to control the submit button, and the last form element before the submit button is a text-field, you should use `updateImmediately` on that field to provide an error as to why the form can't be submitted without the user having to remove focus from that field.

I increased the timeout slightly, as otherwise the error can come in while still typing for a slower typist.

If you don't control the submit button (or the textfield isn't the last value before the button), the default behaviour is now consistent. `onValid` / `onInvalid`update immediately, but the error only appears when focus shifts.

Closes #97.
