### PR TITLE
Fix text input values, and form reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "material-ui": "0.15.0-beta.1",
+    "material-ui": "^0.15.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.4",
     "react": "^15.0.0",

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -18,18 +18,38 @@ const FormsyText = React.createClass({
 
   mixins: [Formsy.Mixin],
 
+
   getInitialState() {
-    return {
-      value: this.props.defaultValue || this.props.value || '',
-    };
+    return { value: this.controlledValue() };
   },
 
   componentWillMount() {
-    this.setValue(this.props.defaultValue || this.props.value || '');
+    this.setValue(this.controlledValue());
   },
-  
-  componentWillReceiveProps(props) {
-    this.setState({ value: this.getValue() || '' });
+
+  componentWillReceiveProps(nextProps) {
+    const isValueChanging = nextProps.value !== this.props.value;
+    if (isValueChanging || nextProps.defaultValue !== this.props.defaultValue) {
+      const value = this.controlledValue(nextProps);
+      if (isValueChanging || this.props.defaultValue === this.getValue()) {
+        this.setState({ value });
+        this.setValue(value);
+      }
+    }
+  },
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState._isPristine && // eslint-disable-line no-underscore-dangle
+      nextState._isPristine !== this.state._isPristine) { // eslint-disable-line no-underscore-dangle
+      // Calling state here is valid, as it cannot cause infinite recursion.
+      const value = this.controlledValue(nextProps);
+      this.setValue(value);
+      this.setState({ value });
+    }
+  },
+
+  controlledValue(props = this.props) {
+    return props.value || props.defaultValue || '';
   },
 
   handleBlur: function handleBlur(event) {

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -1,14 +1,30 @@
 /* eslint-env mocha, jasmine */
 /* global expect */
 
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import FormsyText from '../src/FormsyText';
 import TextField from 'material-ui/TextField';
 import { Simulate } from 'react-addons-test-utils';
 import { mountTestForm } from './support';
 import { Form } from 'formsy-react';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import { mount } from 'enzyme';
 
-const setup = () => {
+function makeChildrenFn(props) {
+  const fn = () => (
+    <FormsyText ref="text"
+      name="text"
+      validations="maxLength:10"
+      validationErrors={{ maxLength: 'Text is too long' }}
+      { ...props }
+    />
+  );
+  fn.DisplayName = 'FormsyText';
+  return fn;
+}
+
+const setup = (props) => {
+  const childrenFn = makeChildrenFn(props);
   const formWrapper = mountTestForm(childrenFn);
   const formsyTextWrapper = formWrapper.find(FormsyText);
   return {
@@ -17,18 +33,51 @@ const setup = () => {
   };
 };
 
-const childrenFn = () => (
-  <FormsyText
-    name="text"
-    validations="maxLength:10"
-    validationErrors={{ maxLength: 'Text is too long' }}
-  />
-);
+class TestForm extends Component {
+
+  static childContextTypes = {
+    muiTheme: PropTypes.object.isRequired,
+  };
+
+  static propTypes = {
+    defaultValue: PropTypes.string,
+    value: PropTypes.string,
+  }
+
+  getChildContext() {
+    return { muiTheme: getMuiTheme() };
+  }
+
+  componentWillMount() {
+    const { value, defaultValue } = this.props;
+    this.state = { value, defaultValue };
+  }
+
+  render() {
+    const { value, defaultValue, ...extraProps } = { ...this.props, ...this.state };
+    return (
+      <Form { ...extraProps }>
+        <FormsyText ref="text" name="text"
+          value={value}
+          defaultValue={defaultValue}
+        />
+      </Form>
+    );
+  }
+}
+
+function makeTestParent(props) {
+  const parent = mount(<TestForm {...props} />);
+  const formWrapper = parent.find(Form);
+  const formsyTextWrapper = parent.find(FormsyText);
+  return { parent, formWrapper, formsyTextWrapper };
+}
 
 const fillInText = (wrapper, text) => {
   const inputDOM = wrapper.find('input').node;
   inputDOM.value = text;
   Simulate.change(inputDOM);
+  Simulate.blur(inputDOM);
 };
 
 describe('FormsyText', () => {
@@ -58,5 +107,133 @@ describe('FormsyText', () => {
     fillInText(formsyTextWrapper, 'just fine');
     formsyForm.validateForm();
     expect(formsyTextWrapper).to.not.contain.text('Text is too long');
+  });
+
+  describe('value properties handle', () => {
+    describe('initial', () => {
+      it('value', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+
+      it('defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('DEFAULT-VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+
+      it('value + defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+    });
+
+    describe('updating', () => {
+      it('value', () => {
+        const props = {
+          value: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ value: 'NEW VALUE' });
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+        parent.setState({ value: 'NEWER VALUE' });
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEWER VALUE');
+      });
+
+      it('defaultValue', () => {
+        const props = {
+          defaultValue: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ defaultValue: 'NEW VALUE' });
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+        fillInText(formsyTextWrapper, 'some text');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+        parent.setState({ defaultValue: 'NEWER VALUE' });
+        // defaultValues does not override the typed in value.
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('some text');
+      });
+    });
+
+    describe('resetting to', () => {
+      it('value', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          defaultValue: 'VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('value + defaultValue', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 'VALUE',
+          defaultValue: 'DEFAULT-VALUE',
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('VALUE');
+      });
+
+      it('updated value', () => {
+        const props = {
+          value: 'VALUE',
+        };
+        const { parent, formWrapper, formsyTextWrapper } = makeTestParent(props);
+        const formsyForm = formWrapper.node;
+        parent.setState({ value: 'NEW VALUE' });
+        fillInText(formsyTextWrapper, 'some text');
+        formsyForm.reset();
+        // Reset reverts to the last value that has been set.
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq('NEW VALUE');
+      });
+    });
   });
 });


### PR DESCRIPTION
This is a replacement and continuation of https://github.com/mbrookes/formsy-material-ui/pull/100. It aims at the following fixes:

1. Instead of

   ```
   this.props.defaultValue || this.props.value || ''
   ```

   we have to use

   ```
   this.props.value || this.props.defaultValue || ''
   ```

   This allows the use of both a defaultValue and a value (controlled case), and allows the value to take precedent. (Currently it's the wrong way around.)

2. Similar to componentWillMount, there is also a need for a componentWillReceiveProps. This covers the case when the form gets reloaded with new values, and allows the defaultValue-s change on the fly, taking care of the pristine values working correctly in this case.

3. The controlledValue I just introduced is just a helper, it does not do anything other than it makes the code shorter.

4. Meanwhile, material-ui 0.15 has been released, so I had to bump the peer dependencies.

5. **Now the additional fix in this PR:** The form.reset() needs to be covered too.

   The previous fix https://github.com/mbrookes/formsy-material-ui/commit/b559bd88d80530d34705907df6837d6f9ba0f742 already meant to fix this. But it does not cover the use cases when defaultValue or value are changing. This means that it was incompatible with my previous PR #100, which is the reason why I created this new one.

   My solution works by detecting if the value becomes from non-pristine to pristine, which happens when a reset is issued. So this covers the reset usecase as well, together with the defaultValue and value cases, as a consequence it's working well in both the controlled and the uncontrolled use cases, and behaves well with reset as well.

I'm testing this for weeks in a project, and it works well with my use case. Sadly, I had no time to bring this fix upstream until now. However seeing that meanwhile, the recent fix targets to fix reset() in a different way, I'd like to ask everyone involved to test my fix for their use case, making sure that it covers the reset() use case as well.
