### PR TITLE
Fix bug with controlled components

### DIFF
--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -12,10 +12,10 @@ const FormsyText = React.createClass({
     onBlur: React.PropTypes.func,
     onChange: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
+    updateImmediately: React.PropTypes.bool,
     validationError: React.PropTypes.string,
     validationErrors: React.PropTypes.object,
     validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
-    updateImmediately: React.PropTypes.bool,
     value: React.PropTypes.any,
   },
 
@@ -23,9 +23,9 @@ const FormsyText = React.createClass({
 
 
   getInitialState() {
-    return { 
+    return {
       value: this.controlledValue(),
-      _isInitial: this.controlledValue() ? false : true,
+      isInitial: this.controlledValue() ? false : true, // eslint-disable-line no-unneeded-ternary
     };
   },
 
@@ -58,19 +58,12 @@ const FormsyText = React.createClass({
     return props.value || props.defaultValue || '';
   },
 
-  // Controlled component
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.props.value)
-    this.setState({
-      value: nextProps.value
-    });
-  },
 
   handleBlur: function handleBlur(event) {
     this.setValue(event.currentTarget.value);
     this.setState({
       value: event.currentTarget.value,
-      _isInitial: event.currentTarget.value ? false : true,
+      isInitial: event.currentTarget.value ? false : true, // eslint-disable-line no-unneeded-ternary
     });
     if (this.props.onBlur) this.props.onBlur(event);
   },
@@ -83,8 +76,7 @@ const FormsyText = React.createClass({
     if (this.props.updateImmediately) {
       this.changeValue(event.currentTarget.value);
     } else {
-      if (!this.state._isInitial)
-      {
+      if (!this.state.isInitial) {
         // If there was an error (on loss of focus) update on each keypress to resolve same.
         if (this.getErrorMessage() != null) {
           this.changeValue(event.currentTarget.value);
@@ -106,7 +98,7 @@ const FormsyText = React.createClass({
     // Uncontrolled component
     } else {
       this.setState({
-        value: event.currentTarget.value
+        value: event.currentTarget.value,
       });
     }
   },
@@ -125,13 +117,13 @@ const FormsyText = React.createClass({
       validationError, // eslint-disable-line no-unused-vars
       validationErrors, // eslint-disable-line no-unused-vars
       value, // eslint-disable-line no-unused-vars
-      ...rest 
+      ...rest,
     } = this.props;
 
     return (
       <TextField
         {...rest}
-        errorText={!this.state._isInitial && this.getErrorMessage()}
+        errorText={!this.state.isInitial && this.getErrorMessage()}
         onBlur={this.handleBlur}
         onChange={this.handleChange}
         onKeyDown={this.handleKeyDown}
@@ -139,7 +131,7 @@ const FormsyText = React.createClass({
         value={this.state.value}
       />
     );
-  }
+  },
 });
 
 export default FormsyText;

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -10,6 +10,7 @@ const FormsyText = React.createClass({
     defaultValue: React.PropTypes.any,
     name: React.PropTypes.string.isRequired,
     onBlur: React.PropTypes.func,
+    onFocus: React.PropTypes.func,
     onChange: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
     updateImmediately: React.PropTypes.bool,
@@ -25,7 +26,7 @@ const FormsyText = React.createClass({
   getInitialState() {
     return {
       value: this.controlledValue(),
-      isInitial: this.controlledValue() ? false : true, // eslint-disable-line no-unneeded-ternary
+      isInitial: false, // eslint-disable-line no-unneeded-ternary
     };
   },
 
@@ -63,9 +64,16 @@ const FormsyText = React.createClass({
     this.setValue(event.currentTarget.value);
     this.setState({
       value: event.currentTarget.value,
-      isInitial: event.currentTarget.value ? false : true, // eslint-disable-line no-unneeded-ternary
+      isInitial: false, // eslint-disable-line no-unneeded-ternary
     });
     if (this.props.onBlur) this.props.onBlur(event);
+  },
+
+  handleFocus: function handleFocus(event) {
+    this.setState({
+      isInitial: event.currentTarget.value ? false : true, // eslint-disable-line no-unneeded-ternary
+    })
+    if (this.props.onFocus) this.props.onFocus(event);
   },
 
   handleChange: function handleChange(event) {
@@ -117,6 +125,9 @@ const FormsyText = React.createClass({
       validationError, // eslint-disable-line no-unused-vars
       validationErrors, // eslint-disable-line no-unused-vars
       value, // eslint-disable-line no-unused-vars
+      onBlur,
+      onChange,
+      onFocus,
       ...rest,
     } = this.props;
 
@@ -126,6 +137,7 @@ const FormsyText = React.createClass({
         errorText={!this.state.isInitial && this.getErrorMessage()}
         onBlur={this.handleBlur}
         onChange={this.handleChange}
+        onFocus={this.handleFocus}
         onKeyDown={this.handleKeyDown}
         ref={this.setMuiComponentAndMaybeFocus}
         value={this.state.value}

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -93,8 +93,6 @@ const FormsyText = React.createClass({
           if (this.isValidValue(event.target.value)) {
             this.changeValue(event.currentTarget.value);
             // If it becomes invalid, and there isn't an error message, invalidate without error.
-          } else {
-            this.resetValue();
           }
         }
       }

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -25,7 +25,7 @@ const FormsyText = React.createClass({
   getInitialState() {
     return { 
       value: this.controlledValue(),
-      _isInitial: true,
+      _isInitial: this.controlledValue() ? false : true,
     };
   },
 

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -45,8 +45,8 @@ const FormsyText = React.createClass({
   },
 
   componentWillUpdate(nextProps, nextState) {
-    if (nextState._isInitial && // eslint-disable-line no-underscore-dangle
-      nextState._isInitial !== this.state._isInitial) { // eslint-disable-line no-underscore-dangle
+    if (nextState._isPristine && // eslint-disable-line no-underscore-dangle
+      nextState._isPristine !== this.state._isPristine) { // eslint-disable-line no-underscore-dangle
       // Calling state here is valid, as it cannot cause infinite recursion.
       const value = this.controlledValue(nextProps);
       this.setValue(value);

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -23,7 +23,10 @@ const FormsyText = React.createClass({
 
 
   getInitialState() {
-    return { value: this.controlledValue() };
+    return { 
+      value: this.controlledValue(),
+      _isInitial: true,
+    };
   },
 
   componentWillMount() {
@@ -42,8 +45,8 @@ const FormsyText = React.createClass({
   },
 
   componentWillUpdate(nextProps, nextState) {
-    if (nextState._isPristine && // eslint-disable-line no-underscore-dangle
-      nextState._isPristine !== this.state._isPristine) { // eslint-disable-line no-underscore-dangle
+    if (nextState._isInitial && // eslint-disable-line no-underscore-dangle
+      nextState._isInitial !== this.state._isInitial) { // eslint-disable-line no-underscore-dangle
       // Calling state here is valid, as it cannot cause infinite recursion.
       const value = this.controlledValue(nextProps);
       this.setValue(value);
@@ -65,6 +68,10 @@ const FormsyText = React.createClass({
 
   handleBlur: function handleBlur(event) {
     this.setValue(event.currentTarget.value);
+    this.setState({
+      value: event.currentTarget.value,
+      _isInitial: event.currentTarget.value ? false : true,
+    });
     delete this.changeValue;
     if (this.props.onBlur) this.props.onBlur(event);
   },
@@ -77,16 +84,19 @@ const FormsyText = React.createClass({
       }
       this.changeValue(event.currentTarget.value);
     } else {
-      // If there was an error (on loss of focus) update on each keypress to resolve same.
-      if (this.getErrorMessage() != null) {
-        this.setValue(event.currentTarget.value);
-      } else {
-        // Only update on valid values, so as to not generate an error until focus is lost.
-        if (this.isValidValue(event.target.value)) {
+      if (!this.state._isInitial)
+      {
+        // If there was an error (on loss of focus) update on each keypress to resolve same.
+        if (this.getErrorMessage() != null) {
           this.setValue(event.currentTarget.value);
-          // If it becomes invalid, and there isn't an error message, invalidate without error.
         } else {
-          this.resetValue();
+          // Only update on valid values, so as to not generate an error until focus is lost.
+          if (this.isValidValue(event.target.value)) {
+            this.setValue(event.currentTarget.value);
+            // If it becomes invalid, and there isn't an error message, invalidate without error.
+          } else {
+            this.resetValue();
+          }
         }
       }
     }
@@ -115,7 +125,6 @@ const FormsyText = React.createClass({
       validations, // eslint-disable-line no-unused-vars
       validationError, // eslint-disable-line no-unused-vars
       validationErrors, // eslint-disable-line no-unused-vars
-      onFocus,
       value, // eslint-disable-line no-unused-vars
       ...rest 
     } = this.props;
@@ -123,7 +132,7 @@ const FormsyText = React.createClass({
     return (
       <TextField
         {...rest}
-        errorText={this.getErrorMessage()}
+        errorText={!this.state._isInitial && this.getErrorMessage()}
         onBlur={this.handleBlur}
         onChange={this.handleChange}
         onKeyDown={this.handleKeyDown}

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -72,27 +72,26 @@ const FormsyText = React.createClass({
       value: event.currentTarget.value,
       _isInitial: event.currentTarget.value ? false : true,
     });
-    delete this.changeValue;
     if (this.props.onBlur) this.props.onBlur(event);
   },
 
   handleChange: function handleChange(event) {
     // Update the value (and so display any error) after a timeout.
+    if (!this.changeValue) {
+      this.changeValue = debounce(this.setValue, 400);
+    }
     if (this.props.updateImmediately) {
-      if (!this.changeValue) {
-        this.changeValue = debounce(this.setValue, 400);
-      }
       this.changeValue(event.currentTarget.value);
     } else {
       if (!this.state._isInitial)
       {
         // If there was an error (on loss of focus) update on each keypress to resolve same.
         if (this.getErrorMessage() != null) {
-          this.setValue(event.currentTarget.value);
+          this.changeValue(event.currentTarget.value);
         } else {
           // Only update on valid values, so as to not generate an error until focus is lost.
           if (this.isValidValue(event.target.value)) {
-            this.setValue(event.currentTarget.value);
+            this.changeValue(event.currentTarget.value);
             // If it becomes invalid, and there isn't an error message, invalidate without error.
           } else {
             this.resetValue();


### PR DESCRIPTION
Controlled components cause validation immediately regardless of the `updateImmediately` prop, and also in one of the last changes `onFocus` was removed from the props of `FormsyText` and it was left omitted from the child with the spread operator in render so focus events ended up not getting passed to MUI.
