### PR TITLE
Fixed FormsyRadioGroup reset

### DIFF
--- a/src/FormsyRadioGroup.jsx
+++ b/src/FormsyRadioGroup.jsx
@@ -12,6 +12,8 @@ const FormsyRadioGroup = React.createClass({
     validationError: React.PropTypes.string,
     validationErrors: React.PropTypes.object,
     validations: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
+    value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.bool]),
+    defaultSelected: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number, React.PropTypes.bool]),
   },
 
   mixins: [Formsy.Mixin],
@@ -28,10 +30,12 @@ const FormsyRadioGroup = React.createClass({
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
   render() {
-    const {
+    let {
       validations, // eslint-disable-line no-unused-vars
       validationError, // eslint-disable-line no-unused-vars
       validationErrors, // eslint-disable-line no-unused-vars
+      defaultSelected,
+      value,
       ...rest } = this.props;
 
       // remove unknown props from children
@@ -45,11 +49,21 @@ const FormsyRadioGroup = React.createClass({
       return React.createElement(RadioButton, rest);
     });
 
+    // For backward compatibility or for
+    // users used to MaterialUI, use the "defaultSelected"
+    // attribute for the "value" if the value was not 
+    // explicitly set.
+    if (typeof value === 'undefined') {
+      value = defaultSelected;
+    }
+
     return (
       <RadioButtonGroup
         {...rest}
         ref={this.setMuiComponentAndMaybeFocus}
         onChange={this.handleValueChange}
+        valueSelected={this.getValue()}
+        defaultSelected={value}
       >
         {children}
       </RadioButtonGroup>


### PR DESCRIPTION
Fixed FormsyRadioGroup to respond to Formsy request to reset form to
original values if they were specified. Also added "value" attribute as
an alias for "defaultSelected" to align FormsyRadioGroup with the other
formsy-material-ui controls (which all use "value" to specify an
initial value).
