### PR TITLE
Fields that have validations don't allow input

### DIFF
--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -77,8 +77,6 @@ const FormsyText = React.createClass({
         if (this.isValidValue(event.target.value)) {
           this.setValue(event.currentTarget.value);
           // If it becomes invalid, and there isn't an error message, invalidate without error.
-        } else {
-          this.resetValue();
         }
       }
     }


### PR DESCRIPTION
Issue #152 - fields that have a validation specification do not allow
input at all if the first character typed causes the field to be
invalid.
