### PR TITLE
Support material-ui 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "material-ui": "^0.15.0",
+    "material-ui": "^0.16.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.4",
     "react": "^15.0.0",


### PR DESCRIPTION
I reviewed the changes in Material UI from 0.15 to 0.16, and I didn't
see any changes that should affect this project. I am using
formsy-material-ui with material-ui 0.16 without any issues (with the
exception of the pull requests I've already made), so I think this is a
simple matter of updating the dependencies in package.json to the new
version of materia-ui