### PR TITLE
Update version for material-ui v0.16 in peerDepencencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "formsy-react": "^0.18.0",
-    "material-ui": "^0.15.0",
+    "material-ui": "^0.16.0",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },
@@ -55,7 +55,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "material-ui": "^0.15.0",
+    "material-ui": "^0.16.0",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.4",
     "react": "^15.0.0",


### PR DESCRIPTION
Material-UI version is required in both peerDependencies and
devDependencies.