### PR TITLE
Make example compatible with react 15.4.x

### DIFF
--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "formsy-react": "^0.18.0",
     "formsy-material-ui": "^0.5.0",
-    "material-ui": "^0.15.0",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1",
-    "react-tap-event-plugin": "^1.0.0"
+    "material-ui": "^0.16.0",
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0",
+    "react-tap-event-plugin": "^2.0.1"
   }
 }


### PR DESCRIPTION
The example provided is currently broken.

```
ERROR in ./~/react-tap-event-plugin/src/injectTapEventPlugin.js
Module not found: Error: Cannot resolve module 'react/lib/EventPluginHub' in /home/kouak/Dev/formsy-material-ui/examples/webpack-example/node_modules/react-tap-event-plugin/src
 @ ./~/react-tap-event-plugin/src/injectTapEventPlugin.js 23:2-37
```

What happens is that the react semver range selected in the example (^15.0.1) will download react 15.4.2 and react-tap-event-plugin 1.0.0.

React 15.4.2 is not compatible with react-tap-event-plugin 1.0.0, breaking the build.

This PR bumps 3 dependency versions :
* Material-ui to ^0.16.0
* react & react-dom to ^15.4.0
* react-tap-event-plugin to ^2.0.1 (compatible with react 15.4).