### PR TITLE
Implement isFormDisabled()

### DIFF
--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -55,6 +55,7 @@ const FormsyAutoComplete = React.createClass({
       ...rest } = this.props;
     return (
       <AutoComplete
+        disabled={this.isFormDisabled()}
         {...rest}
         errorText={this.getErrorMessage()}
         onBlur={this.handleBlur}
@@ -62,7 +63,6 @@ const FormsyAutoComplete = React.createClass({
         onFocus={onFocus}
         onKeyDown={this.handleKeyDown}
         ref={this.setMuiComponentAndMaybeFocus}
-        disabled={this.isFormDisabled()}
         value={this.state.value}
       />
     );

--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -62,6 +62,7 @@ const FormsyAutoComplete = React.createClass({
         onFocus={onFocus}
         onKeyDown={this.handleKeyDown}
         ref={this.setMuiComponentAndMaybeFocus}
+        disabled={this.isFormDisabled()}
         value={this.state.value}
       />
     );

--- a/src/FormsyCheckbox.jsx
+++ b/src/FormsyCheckbox.jsx
@@ -43,6 +43,7 @@ const FormsyCheckbox = React.createClass({
       <Checkbox
         {...rest}
         checked={value}
+        disabled={this.isFormDisabled()}
         onCheck={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
       />

--- a/src/FormsyCheckbox.jsx
+++ b/src/FormsyCheckbox.jsx
@@ -41,9 +41,9 @@ const FormsyCheckbox = React.createClass({
     }
     return (
       <Checkbox
+        disabled={this.isFormDisabled()}
         {...rest}
         checked={value}
-        disabled={this.isFormDisabled()}
         onCheck={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
       />

--- a/src/FormsyDate.jsx
+++ b/src/FormsyDate.jsx
@@ -52,6 +52,7 @@ const FormsyDate = React.createClass({
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
         value={this.getValue()}
+        disabled={this.isFormDisabled()}
       />
     );
   },

--- a/src/FormsyDate.jsx
+++ b/src/FormsyDate.jsx
@@ -47,12 +47,12 @@ const FormsyDate = React.createClass({
     const errorText = this.getErrorMessage() || isRequiredError;
     return (
       <DatePicker
+        disabled={this.isFormDisabled()}
         {...rest}
         errorText={errorText}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
         value={this.getValue()}
-        disabled={this.isFormDisabled()}
       />
     );
   },

--- a/src/FormsyRadioGroup.jsx
+++ b/src/FormsyRadioGroup.jsx
@@ -63,6 +63,7 @@ const FormsyRadioGroup = React.createClass({
         ref={this.setMuiComponentAndMaybeFocus}
         onChange={this.handleValueChange}
         valueSelected={this.getValue()}
+        disabled={this.isFormDisabled()}
         defaultSelected={value}
       >
         {children}

--- a/src/FormsyRadioGroup.jsx
+++ b/src/FormsyRadioGroup.jsx
@@ -59,11 +59,11 @@ const FormsyRadioGroup = React.createClass({
 
     return (
       <RadioButtonGroup
+        disabled={this.isFormDisabled()}
         {...rest}
         ref={this.setMuiComponentAndMaybeFocus}
         onChange={this.handleValueChange}
         valueSelected={this.getValue()}
-        disabled={this.isFormDisabled()}
         defaultSelected={value}
       >
         {children}

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -51,11 +51,11 @@ const FormsySelect = React.createClass({
     const errorText = this.getErrorMessage() || isRequiredError;
     return (
       <SelectField
+        disabled={this.isFormDisabled()}
         {...rest}
         errorText={errorText}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
-        disabled={this.isFormDisabled()}
         value={value}
       >
         {this.props.children}

--- a/src/FormsySelect.jsx
+++ b/src/FormsySelect.jsx
@@ -55,6 +55,7 @@ const FormsySelect = React.createClass({
         errorText={errorText}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
+        disabled={this.isFormDisabled()}
         value={value}
       >
         {this.props.children}

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -123,6 +123,7 @@ const FormsyText = React.createClass({
         onChange={this.handleChange}
         onKeyDown={this.handleKeyDown}
         ref={this.setMuiComponentAndMaybeFocus}
+        disabled={this.isFormDisabled()}
         value={this.getValue()}
         underlineStyle={this.state.isValid ? { color: this.validationColor() } : {}}
         underlineFocusStyle={this.state.isValid ? { color: this.validationColor() } : {}}

--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -117,13 +117,13 @@ const FormsyText = React.createClass({
 
     return (
       <TextField
+        disabled={this.isFormDisabled()}
         {...rest}
         errorText={errorText}
         onBlur={this.handleBlur}
         onChange={this.handleChange}
         onKeyDown={this.handleKeyDown}
         ref={this.setMuiComponentAndMaybeFocus}
-        disabled={this.isFormDisabled()}
         value={this.getValue()}
         underlineStyle={this.state.isValid ? { color: this.validationColor() } : {}}
         underlineFocusStyle={this.state.isValid ? { color: this.validationColor() } : {}}

--- a/src/FormsyTime.jsx
+++ b/src/FormsyTime.jsx
@@ -44,11 +44,11 @@ const FormsyTime = React.createClass({
 
     return (
       <TimePicker
+        disabled={this.isFormDisabled()}
         {...rest}
         errorText={this.getErrorMessage()}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
-        disabled={this.isFormDisabled()}
         value={this.getValue()}
       />
     );

--- a/src/FormsyTime.jsx
+++ b/src/FormsyTime.jsx
@@ -48,6 +48,7 @@ const FormsyTime = React.createClass({
         errorText={this.getErrorMessage()}
         onChange={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
+        disabled={this.isFormDisabled()}
         value={this.getValue()}
       />
     );

--- a/src/FormsyToggle.jsx
+++ b/src/FormsyToggle.jsx
@@ -43,10 +43,10 @@ const FormsyToggle = React.createClass({
 
     return (
       <Toggle
+        disabled={this.isFormDisabled()}
         {...rest}
         onToggle={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
-        disabled={this.isFormDisabled()}
         toggled={value}
       />
     );

--- a/src/FormsyToggle.jsx
+++ b/src/FormsyToggle.jsx
@@ -46,6 +46,7 @@ const FormsyToggle = React.createClass({
         {...rest}
         onToggle={this.handleChange}
         ref={this.setMuiComponentAndMaybeFocus}
+        disabled={this.isFormDisabled()}
         toggled={value}
       />
     );

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -54,13 +54,15 @@ class TestForm extends Component {
   }
 
   render() {
-    const { value, defaultValue, ...extraProps } = { ...this.props, ...this.state };
+    const { value, defaultValue, children, ...extraProps } = { ...this.props, ...this.state };
     return (
       <Form { ...extraProps }>
-        <FormsyText ref="text" name="text"
-          value={value}
-          defaultValue={defaultValue}
-        />
+        {this.props.children ? this.props.children : (
+          <FormsyText ref="text" name="text"
+            value={value}
+            defaultValue={defaultValue}
+          />
+        )}
       </Form>
     );
   }
@@ -148,16 +150,31 @@ describe('FormsyText', () => {
         expect(formValues.text).to.eq('some text');
       });
 
-      it('disabled', () => {
-        const { formsyTextWrapper, formWrapper } = makeTestParent({
-          disabled: true,
-        });
+      it('propagates disabled status', () => {
+        const wrapper = mount(
+          <TestForm disabled={true} >
+            <FormsyText
+              name="text"
+            />
+          </TestForm>
+        );
 
-        const formsyForm = formWrapper.find(Form).node;
-        expect(formsyForm.isFormDisabled()).to.eq(true);
-
-        const inputDOM = formsyTextWrapper.find('input').node;
+        const inputDOM = wrapper.find('input').node;
         expect(inputDOM.disabled).to.eq(true);
+      });
+
+      it('allows overriding disabled status locally', () => {
+        const wrapper = mount(
+          <TestForm disabled={true}>
+            <FormsyText
+              name="text"
+              disabled={false}
+            />
+          </TestForm>
+        );
+
+        const inputDOM = wrapper.find('input').node;
+        expect(inputDOM.disabled).to.eq(false);
       });
     });
 

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -161,10 +161,16 @@ describe('FormsyText', () => {
 
         const inputDOM = wrapper.find('input').node;
         expect(inputDOM.disabled).to.eq(true);
+
+        // Next, we set `disabled` to false and check the DOM node updates accordingly
+        wrapper.setProps({
+          disabled: false,
+        });
+        expect(inputDOM.disabled).to.eq(false);
       });
 
       it('allows overriding disabled status locally', () => {
-        const wrapper = mount(
+        let wrapper = mount(
           <TestForm disabled={true}>
             <FormsyText
               name="text"
@@ -173,8 +179,20 @@ describe('FormsyText', () => {
           </TestForm>
         );
 
-        const inputDOM = wrapper.find('input').node;
+        let inputDOM = wrapper.find('input').node;
         expect(inputDOM.disabled).to.eq(false);
+
+        wrapper = mount(
+          <TestForm disabled={false}>
+            <FormsyText
+              name="text"
+              disabled={true}
+            />
+          </TestForm>
+        );
+
+        inputDOM = wrapper.find('input').node;
+        expect(inputDOM.disabled).to.eq(true);
       });
     });
 

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -40,6 +40,7 @@ class TestForm extends Component {
   };
 
   static propTypes = {
+    children: PropTypes.node,
     defaultValue: PropTypes.string,
     value: PropTypes.string,
   }
@@ -57,7 +58,7 @@ class TestForm extends Component {
     const { value, defaultValue, children, ...extraProps } = { ...this.props, ...this.state };
     return (
       <Form { ...extraProps }>
-        {this.props.children ? this.props.children : (
+        {children ? children : (
           <FormsyText ref="text" name="text"
             value={value}
             defaultValue={defaultValue}

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -179,6 +179,7 @@ describe('FormsyText', () => {
           </TestForm>
         );
 
+        // Here we check we can disable a single input in a globally enabled form
         let inputDOM = wrapper.find('input').node;
         expect(inputDOM.disabled).to.eq(false);
 
@@ -191,6 +192,7 @@ describe('FormsyText', () => {
           </TestForm>
         );
 
+        // Likewise, we are able to keep a specific input enabled even if the form is marked as disabled
         inputDOM = wrapper.find('input').node;
         expect(inputDOM.disabled).to.eq(true);
       });

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -147,6 +147,18 @@ describe('FormsyText', () => {
         formValues = formsyForm.getCurrentValues();
         expect(formValues.text).to.eq('some text');
       });
+
+      it('disabled', () => {
+        const { formsyTextWrapper, formWrapper } = makeTestParent({
+          disabled: true,
+        });
+
+        const formsyForm = formWrapper.find(Form).node;
+        expect(formsyForm.isFormDisabled()).to.eq(true);
+
+        const inputDOM = formsyTextWrapper.find('input').node;
+        expect(inputDOM.disabled).to.eq(true);
+      });
     });
 
     describe('updating', () => {


### PR DESCRIPTION
Fixes #114

This PR allows disabled a Form using the `disabled` prop of the Formsy.Form component.

The disabled status of a specific input can still be overriden with the local `disabled` prop.

I created 2 test cases for FormsyText covering my changes.

