### PR TITLE
add new optional convertValue property to FormsyText

### DIFF
--- a/src/FormsyText.jsx
+++ b/src/FormsyText.jsx
@@ -9,6 +9,7 @@ import { setMuiComponentAndMaybeFocus, debounce } from './utils';
 const FormsyText = createClass({
 
   propTypes: {
+    convertValue: PropTypes.func,
     defaultValue: PropTypes.any,
     name: PropTypes.string.isRequired,
     onBlur: PropTypes.func,
@@ -66,7 +67,7 @@ const FormsyText = createClass({
   },
 
   controlledValue(props = this.props) {
-    return props.value || props.defaultValue || '';
+    return props.value || props.defaultValue || this.convertValue('');
   },
 
   validationColor(props = this.props) {
@@ -74,7 +75,7 @@ const FormsyText = createClass({
   },
 
   handleBlur(event) {
-    this.setValue(event.currentTarget.value);
+    this.setValue(this.convertValue(event.currentTarget.value));
     delete this.changeValue;
     if (this.props.onBlur) this.props.onBlur(event);
   },
@@ -85,15 +86,15 @@ const FormsyText = createClass({
       if (!this.changeValue) {
         this.changeValue = debounce(this.setValue, 400);
       }
-      this.changeValue(event.currentTarget.value);
+      this.changeValue(this.convertValue(event.currentTarget.value));
     } else {
       // If there was an error (on loss of focus) update on each keypress to resolve same.
       if (this.getErrorMessage() != null) {
-        this.setValue(event.currentTarget.value);
+        this.setValue(this.convertValue(event.currentTarget.value));
       } else {
         // Only update on valid values, so as to not generate an error until focus is lost.
         if (this.isValidValue(event.target.value)) {
-          this.setValue(event.currentTarget.value);
+          this.setValue(this.convertValue(event.currentTarget.value));
           // If it becomes invalid, and there isn't an error message, invalidate without error.
         }
       }
@@ -105,8 +106,16 @@ const FormsyText = createClass({
   },
 
   handleKeyDown(event) {
-    if (keycode(event) === 'enter') this.setValue(event.currentTarget.value);
+    if (keycode(event) === 'enter') this.setValue(this.convertValue(event.currentTarget.value));
     if (this.props.onKeyDown) this.props.onKeyDown(event, event.currentTarget.value);
+  },
+
+  convertValue(value) {
+    if (this.props.convertValue) {
+      return this.props.convertValue(value);
+    } else {
+      return value;
+    }
   },
 
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
@@ -114,6 +123,7 @@ const FormsyText = createClass({
   render() {
     const {
       defaultValue, // eslint-disable-line no-unused-vars
+      convertValue, // eslint-disable-line no-unused-vars
       requiredError,
       underlineFocusStyle,
       underlineStyle,

--- a/test/test.FormsyText.js
+++ b/test/test.FormsyText.js
@@ -299,5 +299,42 @@ describe('FormsyText', () => {
         expect(formValues.text).to.eq('NEW VALUE');
       });
     });
+
+    describe('with convertValue', () => {
+      it('converts to number', () => {
+        const { formsyTextWrapper, formWrapper } = setup({
+          value: 1,
+          type: 'number',
+          convertValue: (v) => Number(v),
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        let formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq(1);
+        fillInText(formsyTextWrapper, '2');
+        formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq(2);
+      });
+
+      it('and defaultValue', () => {
+        const { formWrapper } = setup({
+          defaultValue: 1,
+          type: 'number',
+          convertValue: (v) => Number(v),
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq(1);
+      });
+
+      it('and no value', () => {
+        const { formWrapper } = setup({
+          type: 'number',
+          convertValue: (v) => Number(v),
+        });
+        const formsyForm = formWrapper.find(Form).node;
+        const formValues = formsyForm.getCurrentValues();
+        expect(formValues.text).to.eq(0);
+      });
+    });
   });
 });


### PR DESCRIPTION
When using a FormsyText with type="number" for example, the controlled value is
still a string. By specifying a convertValue function, you can convert the value to a number,
before it gets passed to formsy's setValue() for example.

Another example: a user enters the numbers of seconds, and internally it is converted to milliseconds

```
<FormsyText name="millis" value={millis / 1000} convertValue={(v) => Number(v) * 1000}` />
```

The whole thing can be probably applied to a wide range of use cases