### PR TITLE
Fix incorrect import path of setMuiComponentAndMaybeFocus util

### DIFF
--- a/src/FormsyAutoComplete.tsx
+++ b/src/FormsyAutoComplete.tsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import Formsy from 'formsy-react';
 import AutoComplete from 'material-ui/AutoComplete';
-import { setMuiComponentAndMaybeFocus } from 'formsy-react/src/utils';
+
+import { setMuiComponentAndMaybeFocus } from 'utils';
 
 const FormsyAutoComplete = createClass<any, any>({
   propTypes: {


### PR DESCRIPTION
This changes the `setMuiComponentAndMaybeFocus` utility to be correctly imported from the util file.

Closes https://github.com/formsy/formsy-material-ui/issues/242